### PR TITLE
Compatible with Rails 3

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,9 @@
-Example:
+Example (updated for Rails 3):
+
+  # config/routes.rb
+  ..
+  post "/blog/auto_complete_for_post_title" => "blog#auto_complete_for_post_title"
+  ..
 
   # Controller
   class BlogController < ApplicationController
@@ -6,7 +11,11 @@ Example:
   end
 
   # View
-  <%= text_field_with_auto_complete :post, title %>
+  <%= text_field_with_auto_complete :post, :title %>
+
+  # stylesheets 
+  (this is not necesary or even the best fit, but a quick working solution if the boxes doesn't fit nicely below the auto complete textbox)
+  * { margin:0; padding:0; }
 
 By default, auto_complete_for limits the results to 10 entries,
 and sorts by the given field.

--- a/lib/auto_complete_macros_helper.rb
+++ b/lib/auto_complete_macros_helper.rb
@@ -93,9 +93,9 @@ module AutoCompleteMacrosHelper
   #
   # The auto_complete_result can of course also be called from a view belonging to the 
   # auto_complete action if you need to decorate it further.
-  def auto_complete_result(entries, field, phrase = nil)
+  def auto_complete_result(entries, method, phrase = nil)
     return unless entries
-    items = entries.map { |entry| content_tag("li", phrase ? highlight(entry[field], phrase) : h(entry[field])) }
+    items = entries.map { |entry| content_tag("li", phrase ? highlight(entry.send(method.to_sym), phrase) : h(entry.send(method.to_sym))) }
     content_tag("ul", items.uniq)
   end
   

--- a/lib/auto_complete_macros_helper.rb
+++ b/lib/auto_complete_macros_helper.rb
@@ -105,10 +105,11 @@ module AutoCompleteMacrosHelper
   # auto_complete_for to respond the AJAX calls,
   # 
   def text_field_with_auto_complete(object, method, tag_options = {}, completion_options = {})
+    tag_id = tag_options[:id] ? tag_options[:id] : "#{object}_#{method}"
     (completion_options[:skip_style] ? "" : auto_complete_stylesheet) +
     text_field(object, method, tag_options) +
-    content_tag("div", "", :id => "#{object}_#{method}_auto_complete", :class => "auto_complete") +
-    auto_complete_field("#{object}_#{method}", { :url => { :action => "auto_complete_for_#{object}_#{method}" } }.update(completion_options))
+    content_tag("div", "", :id => "#{tag_id}_auto_complete", :class => "auto_complete") +
+    auto_complete_field("#{tag_id}", { :url => { :action => "auto_complete_for_#{object}_#{method}" } }.update(completion_options))
   end
 
   private

--- a/lib/auto_complete_macros_helper.rb
+++ b/lib/auto_complete_macros_helper.rb
@@ -106,7 +106,7 @@ module AutoCompleteMacrosHelper
   # 
   def text_field_with_auto_complete(object, method, tag_options = {}, completion_options = {})
     tag_id = tag_options[:id] ? tag_options[:id] : "#{object}_#{method}"
-    (completion_options[:skip_style] ? "" : auto_complete_stylesheet) +
+    (completion_options[:skip_style] ? "".html_safe : auto_complete_stylesheet) +
     text_field(object, method, tag_options) +
     content_tag("div", "", :id => "#{tag_id}_auto_complete", :class => "auto_complete") +
     auto_complete_field("#{tag_id}", { :url => { :action => "auto_complete_for_#{object}_#{method}" } }.update(completion_options))

--- a/lib/auto_complete_macros_helper.rb
+++ b/lib/auto_complete_macros_helper.rb
@@ -95,8 +95,8 @@ module AutoCompleteMacrosHelper
   # auto_complete action if you need to decorate it further.
   def auto_complete_result(entries, method, phrase = nil)
     return unless entries
-    items = entries.map { |entry| content_tag("li", phrase ? highlight(entry.send(method.to_sym), phrase) : h(entry.send(method.to_sym))) }
-    content_tag("ul", items.uniq)
+    items = entries.map { |entry| raw(content_tag("li", phrase ? highlight(entry.send(method.to_sym), phrase) : h(entry.send(method.to_sym)))) }
+    content_tag("ul", items.uniq.join.html_safe).html_safe
   end
   
   # Wrapper for text_field with added AJAX autocompletion functionality.


### PR DESCRIPTION
Hi,

I've added 2 commits to the main repo, allowing to:
- Show custom text for each instance found on the view (by specifying a method name to invoke, instead of just calling an attribute value)
- Making the options of auto_complete_result html_safe, so that it works well with Rails 3 apps
